### PR TITLE
Synthetic

### DIFF
--- a/conf/synthetic/long_servedio.yaml
+++ b/conf/synthetic/long_servedio.yaml
@@ -12,6 +12,7 @@ phuber_tau: 1.36 # ~ 1 + exp(-1)
 corrupt_prob: 0.2
 gamma: 0.0417 # ~ 1/24
 var: 0.0001
+mixture: true
 seed: null
 method: slsqp
 plot_boundaries: false # avoid calling for many repeats

--- a/synthetic/dataset.py
+++ b/synthetic/dataset.py
@@ -36,18 +36,8 @@ def long_servedio_simple(
         * N
     )
 
-    labels = []
-    for _ in range(N):
-        flip = np.random.choice([-1, 1], p=[corrupt_prob, 1 - corrupt_prob])
-        labels.extend(
-            [
-                flip,  # "Noisy Large Margin"
-                1,  # "+1 Penalizer 1"
-                1,  #  "+1 Penalize 2"
-                1,  #  "+1 Puller""
-            ]
-        )
-    labels = np.array(labels)
+    #  all positive by default, corrupt to negative with given probability
+    labels = np.random.choice([-1, 1], p=[corrupt_prob, 1 - corrupt_prob], size=(N * 4))
 
     return samples, labels
 

--- a/synthetic/dataset.py
+++ b/synthetic/dataset.py
@@ -28,14 +28,16 @@ def long_servedio_simple(
     if noise_seed is not None:
         np.random.seed(noise_seed)
 
-    samples = np.array(
-        [
-            [1, 0],  #  "Large Margin"
-            [gamma, -gamma],  # "Penalizer 1"
-            [gamma, -gamma],  # "Penalizer 2"
-            [gamma, 5 * gamma],  # "Puller"
-        ]
-        * N
+    samples = np.repeat(
+        np.array(
+            [
+                [1, 0],  #  "Large Margin"
+                [gamma, -gamma],  # "Penalizer 1"
+                [gamma, -gamma],  # "Penalizer 2"
+                [gamma, 5 * gamma],  # "Puller"
+            ]
+        ),
+        N,
     )
 
     #  all positive by default, corrupt to negative with given probability
@@ -135,12 +137,22 @@ def outlier_dataset(seed=None) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.n
         [np.random.normal(1, 1, 5000), np.random.normal(-1, 1, 5000)]
     )
 
-    inlier_labels = np.concatenate([np.ones((5000,)), -1 * np.ones((5000,)),])
+    inlier_labels = np.concatenate(
+        [
+            np.ones((5000,)),
+            -1 * np.ones((5000,)),
+        ]
+    )
 
     outlier_feats = np.concatenate(
         [np.random.normal(-200, 1, 25), np.random.normal(200, 1, 25)]
     )
 
-    outlier_labels = np.concatenate([np.ones((25,)), -1 * np.ones((25,)),])
+    outlier_labels = np.concatenate(
+        [
+            np.ones((25,)),
+            -1 * np.ones((25,)),
+        ]
+    )
 
     return inlier_feats, inlier_labels, outlier_feats, outlier_labels

--- a/synthetic/dataset.py
+++ b/synthetic/dataset.py
@@ -8,8 +8,9 @@ def long_servedio_simple(
     gamma: float = 1.0 / 24.0,
     corrupt_prob: float = 0.45,
     noise_seed: Optional[int] = None,
+    enforce_symmetry: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Generates 4 sample Long & Servedio (with noisy margin) dataset from
+    """Generates 4 sample Long & Servedio dataset from
     `"Random Classification Noise Defeats All Convex Potential Boosters"
     <http://www.cs.columbia.edu/~rocco/Public/icml08-cameraready.pdf>`_
 
@@ -18,6 +19,7 @@ def long_servedio_simple(
         gamma: specifies location of each atom
         corrupt_prob: applied label noise
         noise_seed: seed for applying label noise
+        enforce_symmetry: whether to use same amount of noisy samples
 
     Returns:
         samples: numpy array of size :math:`(N, 2)`
@@ -37,7 +39,14 @@ def long_servedio_simple(
     )
 
     #  all positive by default, corrupt to negative with given probability
-    labels = np.random.choice([-1, 1], p=[corrupt_prob, 1 - corrupt_prob], size=(N * 4))
+    if enforce_symmetry:
+        labels = np.repeat(  # same amount of noised versions
+            np.random.choice([-1, 1], p=[corrupt_prob, 1 - corrupt_prob], size=(N)), 4
+        )
+    else:
+        labels = np.random.choice(
+            [-1, 1], p=[corrupt_prob, 1 - corrupt_prob], size=(N * 4)
+        )
 
     return samples, labels
 

--- a/synthetic/dataset.py
+++ b/synthetic/dataset.py
@@ -59,7 +59,7 @@ def long_servedio_dataset(
         label = 1 if x[0] >= 0 else -1
 
         # randomly flip with corrupt probability
-        flip = np.random.choice([-1, 1], p=[1 - corrupt_prob, corrupt_prob])
+        flip = np.random.choice([-1, 1], p=[corrupt_prob, 1 - corrupt_prob])
         label = label * flip
 
         # store sample and label

--- a/synthetic/dataset.py
+++ b/synthetic/dataset.py
@@ -3,6 +3,55 @@ from typing import Optional, Tuple
 import numpy as np
 
 
+def long_servedio_simple(
+    N: int = 1000,
+    gamma: float = 1.0 / 24.0,
+    corrupt_prob: float = 0.45,
+    noise_seed: Optional[int] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generates 4 sample Long & Servedio (with noisy margin) dataset from
+    `"Random Classification Noise Defeats All Convex Potential Boosters"
+    <http://www.cs.columbia.edu/~rocco/Public/icml08-cameraready.pdf>`_
+
+    Args:
+        N: number of samples
+        gamma: specifies location of each atom
+        corrupt_prob: applied label noise
+        noise_seed: seed for applying label noise
+
+    Returns:
+        samples: numpy array of size :math:`(N, 2)`
+        labels: numpy array of size :math:`(N)` with :math:`\pm1` labels
+    """
+    if noise_seed is not None:
+        np.random.seed(noise_seed)
+
+    samples = np.array(
+        [
+            [1, 0],  #  "Large Margin"
+            [gamma, -gamma],  # "Penalizer 1"
+            [gamma, -gamma],  # "Penalizer 2"
+            [gamma, 5 * gamma],  # "Puller"
+        ]
+        * N
+    )
+
+    labels = []
+    for _ in range(N):
+        flip = np.random.choice([-1, 1], p=[corrupt_prob, 1 - corrupt_prob])
+        labels.extend(
+            [
+                flip,  # "Noisy Large Margin"
+                1,  # "+1 Penalizer 1"
+                1,  #  "+1 Penalize 2"
+                1,  #  "+1 Puller""
+            ]
+        )
+    labels = np.array(labels)
+
+    return samples, labels
+
+
 def long_servedio_dataset(
     N: int = 1000,
     gamma: float = 1.0 / 24.0,
@@ -10,7 +59,7 @@ def long_servedio_dataset(
     corrupt_prob: float = 0.45,
     noise_seed: Optional[int] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Generates samples from  mixture of 6 isotropic Gaussians,
+    """Generates samples from mixture of 6 isotropic Gaussians,
      which is a slight variation of the Long & Servedio dataset from
     `"Random Classification Noise Defeats All Convex Potential Boosters"
     <http://www.cs.columbia.edu/~rocco/Public/icml08-cameraready.pdf>`_
@@ -87,22 +136,12 @@ def outlier_dataset(seed=None) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.n
         [np.random.normal(1, 1, 5000), np.random.normal(-1, 1, 5000)]
     )
 
-    inlier_labels = np.concatenate(
-        [
-            np.ones((5000,)),
-            -1 * np.ones((5000,)),
-        ]
-    )
+    inlier_labels = np.concatenate([np.ones((5000,)), -1 * np.ones((5000,)),])
 
     outlier_feats = np.concatenate(
         [np.random.normal(-200, 1, 25), np.random.normal(200, 1, 25)]
     )
 
-    outlier_labels = np.concatenate(
-        [
-            np.ones((25,)),
-            -1 * np.ones((25,)),
-        ]
-    )
+    outlier_labels = np.concatenate([np.ones((25,)), -1 * np.ones((25,)),])
 
     return inlier_feats, inlier_labels, outlier_feats, outlier_labels

--- a/synthetic/experiments.py
+++ b/synthetic/experiments.py
@@ -92,7 +92,12 @@ def long_servedio_experiment(cfg: DictConfig) -> None:
             # train linear model
             if cfg.method == "slsqp":
                 weights, _ = train_linear_slsqp(
-                    samples=train_samples, labels=train_labels, loss_fn=loss_fns[i]
+                    samples=train_samples,
+                    labels=train_labels,
+                    loss_fn=loss_fns[i],
+                    max_iter=cfg.max_iter
+                    if cfg.get("max_iter", None) is not None
+                    else 100,
                 )
             elif cfg.method == "sgd":
                 weights, _ = train_linear_sgd(

--- a/synthetic/experiments.py
+++ b/synthetic/experiments.py
@@ -73,12 +73,18 @@ def long_servedio_experiment(cfg: DictConfig) -> None:
                 gamma=cfg.gamma,
                 corrupt_prob=cfg.corrupt_prob,
                 noise_seed=cfg.seed,
+                enforce_symmetry=cfg.enforce_symmetry
+                if cfg.get("enforce_symmetry", None) is not None
+                else False,
             )
             test_samples, test_labels = long_servedio_simple(
                 N=cfg.n_test,
                 gamma=cfg.gamma,
                 corrupt_prob=0.0,
                 noise_seed=cfg.seed + 1 if cfg.seed else None,
+                enforce_symmetry=cfg.enforce_symmetry
+                if cfg.get("enforce_symmetry", None) is not None
+                else False,
             )
 
         #  iterate over losses

--- a/synthetic/experiments.py
+++ b/synthetic/experiments.py
@@ -90,6 +90,7 @@ def long_servedio_experiment(cfg: DictConfig) -> None:
                     weights,
                     train_samples,
                     train_labels,
+                    title=losses_text[i],
                     show=cfg.show_fig,
                     save=cfg.save_fig,
                     save_name=f"boundaries_{losses_text[i]}.png",

--- a/synthetic/linear.py
+++ b/synthetic/linear.py
@@ -42,7 +42,7 @@ def train_linear_sgd(
 
 
 def train_linear_slsqp(
-    samples: np.ndarray, labels: np.ndarray, loss_fn: Callable
+    samples: np.ndarray, labels: np.ndarray, loss_fn: Callable, max_iter: int = 100
 ) -> Tuple[np.ndarray, float]:
     """Trains a linear classifier with SLSQP from scipy
 
@@ -53,7 +53,11 @@ def train_linear_slsqp(
 
     # optimize with scipy SLSQP
     opt_result = optimize.minimize(
-        linear_objective, weights, (samples, labels, loss_fn), method="SLSQP"
+        linear_objective,
+        weights,
+        (samples, labels, loss_fn),
+        method="SLSQP",
+        options={"maxiter": max_iter},
     )
 
     # return weights of the linear classifier

--- a/synthetic/loss.py
+++ b/synthetic/loss.py
@@ -142,4 +142,3 @@ def partially_huberised_gradient(
         # logistic gradient (1-z) to get sigmoid(-z)
         (-(1 - z) * y) * x,
     )
-

--- a/synthetic/loss.py
+++ b/synthetic/loss.py
@@ -143,7 +143,3 @@ def partially_huberised_gradient(
         (-(1 - z) * y) * x,
     )
 
-
-def empirical_risk_logistic_loss(labels, feats, theta):
-    risk = np.mean(logistic_loss(labels * feats * theta))
-    return risk

--- a/synthetic/plots.py
+++ b/synthetic/plots.py
@@ -9,6 +9,7 @@ def plot_boundaries(
     w: np.ndarray,
     samples: np.ndarray,
     labels: np.ndarray,
+    title: str,
     show=True,
     save=False,
     save_name="boundaries.png",
@@ -43,6 +44,7 @@ def plot_boundaries(
     plt.scatter(
         samples[labels == 1, 0], samples[labels == 1, 1], s=0.2, c="blue", alpha=0.5
     )
+    plt.title(title)
 
     if save:
         plt.savefig(save_name)


### PR DESCRIPTION
* Fixes random seeds problem: 
We were using the same seed for all trials, when the user specifies the seed! This PR solves this issue by initialization different seeds for each trial _with the given seed_.

* Removes unused and undocumented method  from `loss.py`

* We were flipping with `1-p` probability instead of `p` which shouldn't be problem due to symmetric setup. But, to match the notation of Long & Servedio and the original paper, this PR uses correct corruption probabilities.

* Now, using SLSPQ by default 100 maximum iterations (provided by the authors). Maximum iterations is configurable through `hydra` with `+max_iters`

* Adds the `4 sample` setup from Long & Servedio which is accessible through `mixture: false` option. 