### PR TITLE
Update config to support Hydra 1.1

### DIFF
--- a/conf/dataset/cifar10.yaml
+++ b/conf/dataset/cifar10.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: cifar10
 root: data/
 download: true # download if not already downloaded

--- a/conf/dataset/cifar100.yaml
+++ b/conf/dataset/cifar100.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: cifar100
 root: data/
 download: true # download if not already downloaded

--- a/conf/dataset/mnist.yaml
+++ b/conf/dataset/mnist.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: mnist
 root: data/
 download: true # download if not already downloaded

--- a/conf/eval.yaml
+++ b/conf/eval.yaml
@@ -2,5 +2,5 @@ defaults:
   - dataset: mnist
   - model: lenet
   - misc: eval_misc
-  - hydra/job_logging: custom
-  - hydra/output: custom
+  - override hydra/job_logging: custom
+  - override hydra/output: custom

--- a/conf/hparams/optimizer/adam.yaml
+++ b/conf/hparams/optimizer/adam.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # By default, this group is not activated
 # If you want to change the optimizer from the default one in the configuration, \
 # override with +hparams/optimizer

--- a/conf/hparams/optimizer/sgd.yaml
+++ b/conf/hparams/optimizer/sgd.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # By default, this group is not activated
 # If you want to change the optimizer from the default one in the configuration, \
 # override with +hparams/optimizer

--- a/conf/hydra/job_logging/custom.yaml
+++ b/conf/hydra/job_logging/custom.yaml
@@ -1,5 +1,3 @@
-# @package _group_
-
 # python logging configuration for tasks
 version: 1
 formatters:

--- a/conf/loss/ce.yaml
+++ b/conf/loss/ce.yaml
@@ -1,2 +1,1 @@
-# @package _group_
 _target_: phuber.loss.CrossEntropy

--- a/conf/loss/gce.yaml
+++ b/conf/loss/gce.yaml
@@ -1,3 +1,2 @@
-# @package _group_
 _target_: phuber.loss.GeneralizedCrossEntropy
 q: 0.7

--- a/conf/loss/linear.yaml
+++ b/conf/loss/linear.yaml
@@ -1,2 +1,1 @@
-# @package _group_
 _target_: phuber.loss.Unhinged

--- a/conf/loss/phuber_ce.yaml
+++ b/conf/loss/phuber_ce.yaml
@@ -1,3 +1,2 @@
-# @package _group_
 _target_: phuber.loss.PHuberCrossEntropy
 tau: 10

--- a/conf/loss/phuber_gce.yaml
+++ b/conf/loss/phuber_gce.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: phuber.loss.PHuberGeneralizedCrossEntropy
 q: 0.7
 tau: 10

--- a/conf/loss/pytorch_ce.yaml
+++ b/conf/loss/pytorch_ce.yaml
@@ -1,2 +1,1 @@
-# @package _group_
 _target_: torch.nn.CrossEntropyLoss

--- a/conf/model/lenet.yaml
+++ b/conf/model/lenet.yaml
@@ -1,2 +1,1 @@
-# @package _group_
 _target_: phuber.network.LeNet

--- a/conf/model/resnet18.yaml
+++ b/conf/model/resnet18.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: phuber.network.resnet18
 # num_classes gets set to 10 when used with cifar-10, to 100 when used with cifar-100
 # more info: https://hydra.cc/docs/patterns/specializing_config

--- a/conf/model/resnet50.yaml
+++ b/conf/model/resnet50.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: phuber.network.resnet50
 # num_classes gets set to 10 when used with cifar-10, to 100 when used with cifar-100
 # more info: https://hydra.cc/docs/patterns/specializing_config

--- a/conf/train.yaml
+++ b/conf/train.yaml
@@ -2,9 +2,8 @@ defaults:
   - dataset: mnist
   - model: lenet
   - loss: phuber_ce
-  - hparams: ${defaults.0.dataset}_${defaults.1.model} # change when Hydra 1.1 releases
-    optional: false # more info: https://hydra.cc/docs/patterns/specializing_config
+  - hparams: ${dataset}_${model}
     # Note: hyper-parameters are automatically set when specifying dataset and model
   - misc: train_misc
-  - hydra/job_logging: custom
-  - hydra/output: custom
+  - override hydra/job_logging: custom
+  - override hydra/output: custom

--- a/phuber/runner.py
+++ b/phuber/runner.py
@@ -136,7 +136,7 @@ def evaluate(cfg: DictConfig) -> None:
         evaluator = Evaluator(
             model=model,
             device=device,
-            loader=test_loader,
+            loader=val_loader,
             checkpoint_path=checkpoint_path,
         )
         evaluator.evaluate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 torch>=1.7
 torchvision
 tensorboard
-hydra-core
+hydra-core>=1.1.0
 tqdm
 matplotlib
 seaborn


### PR DESCRIPTION
Updates configuration to be compatible with Hydra 1.1 (and higher). Deprecate support for Hydra 1.0.

More info:
Hydra 1.1 release: https://hydra.cc/blog/2021/06/13/Hydra_1.1
Upgrading Hydra version: https://hydra.cc/docs/upgrades/intro